### PR TITLE
Bug fixed, Contact information form

### DIFF
--- a/admin/contactus.php
+++ b/admin/contactus.php
@@ -28,7 +28,7 @@ include 'includes/header.php';
 			echo $pageMsg;
 		}
 		?>
-			<form role="contactForm" method="post" action="contact_me.php">
+			<form role="contactForm" method="post" action="">
 
 				<div class="form-group">
 					<label>Heading</label>


### PR DESCRIPTION
in 31 line I fixed form action bug, Action doesn't need call to action="contact-me.php".
So you don't need use action in this class. This must be empty.